### PR TITLE
Fix removeItem functionality

### DIFF
--- a/LocalStorage.elm
+++ b/LocalStorage.elm
@@ -130,5 +130,5 @@ not available in the browser:
 
 -}
 remove : String -> Task Error String
-remove key =
+remove =
   Native.LocalStorage.remove


### PR DESCRIPTION
The remove function on the elm side was slurping up the "key"
parameter without passing it through to the native remove
function, causing a runtime error. This change alters the remove
function to be a simple passthrough (like set) so that all params
are sent to the native remove function.
